### PR TITLE
Update to support Oauth + User Streams

### DIFF
--- a/oauth_example.rb
+++ b/oauth_example.rb
@@ -1,0 +1,12 @@
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), 'lib'))
+
+require 'rubygems'
+require 'tweetstream'
+
+@oauth = { :consumer_key => YOUR_CONSUMER_TOKEN_HERE,
+          :consumer_secret => YOUR_CONSUMER_SECRET_HERE,
+          :access_key => YOUR_ACCESS_KEY_HERE,
+          :access_secret => YOUR_ACCESS_SECRET_HERE }
+
+client = TweetStream::Client.new(:oauth => @oauth)
+client.user_stream { |status| p status }


### PR DESCRIPTION
Hi Michael,

Thanks for the great work on this gem! It's definitely been a big help.

With the introduction of User Streams I thought you might have people looking to use OAuth with tweetstream. I've gone ahead and added in this support.

You will need to update to my fork of twitter-stream as well, and you should not pull these changes as-is; I've not finished building out all that it should support.

However, it will give you a good sense of where to make the OAuth changes. Take a look at oauth_example.rb to get an idea of what I'm proposing. With this approach you can pass in either a oauth 4-member hash (which is then passed on to roauth) or you can pass in a username/password.

Take a look; if I had more time I'd clean it up further.

Best,
Dave
