### PR TITLE
Unbreak on Linux.

### DIFF
--- a/lib/tweetstream/client.rb
+++ b/lib/tweetstream/client.rb
@@ -304,7 +304,7 @@ module TweetStream
       }.merge(auth_params).merge(extra_stream_parameters)
 
       EventMachine.epoll
-      EventMachine.kqueue = EM.kqueue?
+      EventMachine.kqueue
 
       EventMachine::run {
         if @on_interval_proc.is_a?(Proc)


### PR DESCRIPTION
I'm getting the following exception under Linux.

```
/home/bernd/.rvm/gems/ruby-1.9.3-head/bundler/gems/tweetstream e414317ab775/lib/tweetstream/client.rb:307:in `kqueue=': kqueue is not supported on this platform (EventMachine::Unsupported)
```

EM.kqueue= can only be used on a system that actually supports kqueue. Calling EM.kqueue is just fine since it's a no-op on operating systems without kqueue support.
