### PR TITLE
Make TweetStream::Configuration#options compatible with Ruby 1.8.6

### DIFF
--- a/lib/tweetstream/configuration.rb
+++ b/lib/tweetstream/configuration.rb
@@ -65,7 +65,7 @@ module TweetStream
 
     # Create a hash of options and their values
     def options
-      Hash[VALID_OPTIONS_KEYS.map {|key| [key, send(key)] }]
+      Hash[*VALID_OPTIONS_KEYS.map {|key| [key, send(key)] }.flatten]
     end
 
     # Reset all configuration options to defaults


### PR DESCRIPTION
This is the only error I've seen from running in Ruby 1.8.6, everything else works perfectly.
