### PR TITLE
Verify the chosen JSON parser is valid and can be loaded

### DIFF
--- a/lib/tweetstream/client.rb
+++ b/lib/tweetstream/client.rb
@@ -31,6 +31,9 @@ module TweetStream
       Configuration::VALID_OPTIONS_KEYS.each do |key|
         send("#{key}=", options[key])
       end
+      
+      # Ensure the json parser can be properly loaded
+      json_parser
     end
 
     # Get the JSON parser class for this client.


### PR DESCRIPTION
The system previously did not do any validation on the provided json parser.  This meant it was not invoked until it was inside the EventMachine loop.  It is unlikely anyone would want to handle an invalid parser during the event loop instead of fixing the initialization error.  I added this check to avoid problems like I had where the client was dying silently due to a configuration typo.
