### PR TITLE
Adding TweetStream::Client.shutdown_stream to cleanly stop the stream

### DIFF
--- a/lib/tweetstream/client.rb
+++ b/lib/tweetstream/client.rb
@@ -424,6 +424,10 @@ module TweetStream
       @stream.close_connection if @stream
     end
 
+    def stop_stream
+      @stream.stop if @stream
+    end
+
     protected
 
     def parser_from(parser)

--- a/spec/tweetstream/client_spec.rb
+++ b/spec/tweetstream/client_spec.rb
@@ -363,6 +363,34 @@ describe TweetStream::Client do
     end
   end
 
+  describe '#stop_stream' do
+    before(:each) do
+      @stream = stub("Twitter::JSONStream",
+        :connect => true,
+        :unbind => true,
+        :each_item => true,
+        :on_error => true,
+        :on_max_reconnects => true,
+        :on_reconnect => true,
+        :connection_completed => true,
+        :stop => true
+      )
+      Twitter::JSONStream.stub!(:connect).and_return(@stream)
+      @client = TweetStream::Client.new
+      @client.connect('/')
+    end
+
+    it "should call stream.stop to cleanly stop the current stream" do
+      @stream.should_receive(:stop)
+      @client.stop_stream
+    end
+
+    it 'should not stop eventmachine' do
+      EventMachine.should_not_receive :stop_event_loop
+      @client.stop_stream
+    end
+  end
+
   describe "oauth" do
     describe '#start' do
       before do


### PR DESCRIPTION
Note this does not touch the running `EventMachine`, it just tells the underlying connection to shut down.

I need this mechanism to be able to start/stop `TweetStream::Client` instances inside of a long-running `EventMachine`.

Regards
Laust Rud Jacobsen
http://object.io
