### PR TITLE
Added enhance_your_calm callback.

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ JSON parser and it will be used to parse responses.
 Sometimes the Streaming API will send messages other than statuses.
 Specifically, it does so when a status is deleted or rate limitations
 have caused some tweets not to appear in the stream. To handle these,
-you can use the on_delete and on_limit methods. Example:
+you can use the on_delete, on_limit and on_enhance_your_calm methods. Example:
 
 ```ruby
 @client = TweetStream::Client.new
@@ -223,6 +223,10 @@ you can use the on_delete and on_limit methods. Example:
 end
 
 @client.on_limit do |skip_count|
+  # do something
+end
+
+@client.on_enhance_your_calm do
   # do something
 end
 

--- a/lib/tweetstream/client.rb
+++ b/lib/tweetstream/client.rb
@@ -348,6 +348,21 @@ module TweetStream
       end
     end
 
+    # Set a Proc to be run when enhance_your_calm signal is received.
+    #
+    #     @client = TweetStream::Client.new
+    #     @client.on_enhance_your_calm do
+    #       # do something, your account has been blocked
+    #     end
+    def on_enhance_your_calm(&block)
+      if block_given?
+        @on_enhance_your_calm = block
+        self
+      else
+        @on_enhance_your_calm
+      end
+    end
+
     # connect to twitter while starting a new EventMachine run loop
     def start(path, query_parameters = {}, &block)
       if EventMachine.reactor_running?
@@ -369,6 +384,7 @@ module TweetStream
       scrub_geo_proc = query_parameters.delete(:scrub_geo) || self.on_scrub_geo
       limit_proc = query_parameters.delete(:limit) || self.on_limit
       error_proc = query_parameters.delete(:error) || self.on_error
+      enhance_your_calm_proc = query_parameters.delete(:enhance_your_calm) || self.on_error
       unauthorized_proc = query_parameters.delete(:unauthorized) || self.on_unauthorized
       reconnect_proc = query_parameters.delete(:reconnect) || self.on_reconnect
       inited_proc = query_parameters.delete(:inited) || self.on_inited
@@ -456,6 +472,10 @@ module TweetStream
 
       @stream.on_unauthorized do
         unauthorized_proc.call if unauthorized_proc.is_a?(Proc)
+      end
+
+      @stream.on_enhance_your_calm do
+        enhance_your_calm_proc.call if enhance_your_calm_proc.is_a?(Proc)
       end
 
       @stream.on_reconnect do |timeout, retries|

--- a/spec/tweetstream/client_spec.rb
+++ b/spec/tweetstream/client_spec.rb
@@ -58,7 +58,8 @@ describe TweetStream::Client do
         :on_reconnect => true,
         :connection_completed => true,
         :on_no_data_received => true,
-        :on_unauthorized => true
+        :on_unauthorized => true,
+        :on_enhance_your_calm => true
       )
       EM.stub!(:run).and_yield
       EM::Twitter::Client.stub!(:connect).and_return(@stream)
@@ -326,7 +327,7 @@ describe TweetStream::Client do
     end
   end
 
-  %w(on_delete on_limit on_inited on_reconnect on_no_data_received on_unauthorized).each do |proc_setter|
+  %w(on_delete on_limit on_inited on_reconnect on_no_data_received on_unauthorized on_enhance_your_calm).each do |proc_setter|
     describe "##{proc_setter}" do
       it 'should set when a block is given' do
         proc = Proc.new{|a,b| puts a }
@@ -373,6 +374,7 @@ describe TweetStream::Client do
         :connection_completed => true,
         :on_no_data_received => true,
         :on_unauthorized => true,
+        :on_enhance_your_calm => true,
         :stop => true
       )
       EM::Twitter::Client.stub!(:connect).and_return(@stream)
@@ -409,7 +411,8 @@ describe TweetStream::Client do
         :on_reconnect => true,
         :connection_completed => true,
         :on_no_data_received => true,
-        :on_unauthorized => true
+        :on_unauthorized => true,
+        :on_enhance_your_calm => true
       )
       EM.stub!(:run).and_yield
       EM::Twitter::Client.stub!(:connect).and_return(@stream)
@@ -453,7 +456,8 @@ describe TweetStream::Client do
           :on_reconnect => true,
           :connection_completed => true,
           :on_no_data_received => true,
-          :on_unauthorized => true
+          :on_unauthorized => true,
+          :on_enhance_your_calm => true
         )
         EM.stub!(:run).and_yield
         EM::Twitter::Client.stub!(:connect).and_return(@stream)

--- a/spec/tweetstream/site_stream_client_spec.rb
+++ b/spec/tweetstream/site_stream_client_spec.rb
@@ -101,6 +101,7 @@ describe TweetStream::SiteStreamClient do
         end
         called.should be_true
       end
+
     end
   end
 

--- a/spec/tweetstream_spec.rb
+++ b/spec/tweetstream_spec.rb
@@ -16,7 +16,8 @@ describe TweetStream do
         :on_reconnect => true,
         :connection_completed => true,
         :on_no_data_received => true,
-        :on_unauthorized => true
+        :on_unauthorized => true,
+        :on_enhance_your_calm => true
       )
       EM.stub!(:run).and_yield
       EM::Twitter::Client.stub!(:connect).and_return(@stream)


### PR DESCRIPTION
Hello,

This callback is raised by em-twitter, and actually is different from `on_limit`, corresponding to a 420 http code status.

See : https://dev.twitter.com/docs/error-codes-responses
