### PR TITLE
client.enhance_your_calm block never gets called

### DIFF
--- a/lib/tweetstream/client.rb
+++ b/lib/tweetstream/client.rb
@@ -385,7 +385,7 @@ module TweetStream
       scrub_geo_proc = query_parameters.delete(:scrub_geo) || self.on_scrub_geo
       limit_proc = query_parameters.delete(:limit) || self.on_limit
       error_proc = query_parameters.delete(:error) || self.on_error
-      enhance_your_calm_proc = query_parameters.delete(:enhance_your_calm) || self.on_error
+      enhance_your_calm_proc = query_parameters.delete(:enhance_your_calm) || self.on_enhance_your_calm
       unauthorized_proc = query_parameters.delete(:unauthorized) || self.on_unauthorized
       reconnect_proc = query_parameters.delete(:reconnect) || self.on_reconnect
       inited_proc = query_parameters.delete(:inited) || self.on_inited


### PR DESCRIPTION
In the example code below, `on_enhance_your_calm` never gets called even when that's the response Twitter is sending. Instead, `on_error` gets called with a nil `message`.

``` ruby
    TweetStream.configure do |config|
      config.username     = ENV["TWITTER_HANDLE"]
      config.password     =  ENV["TWITTER_PASSWORD"]
      config.auth_method  = :basic
    end

    client = TweetStream::Client.new

    client.on_enhance_your_calm do
      puts "Enhance Your Calm"
    end

    client.on_error do |message|
      puts "Error: #{message}"
    end

    client.track(hashtag) do |tweet|
      puts tweet.inspect
    end
```
