### PR TITLE
Allow normalized_user_ids() to accept single IDs

### DIFF
--- a/lib/tweetstream/site_stream_client.rb
+++ b/lib/tweetstream/site_stream_client.rb
@@ -115,7 +115,11 @@ module TweetStream
     end
 
     def normalized_user_ids(user_id)
-      user_id.join(',') if user_id.kind_of?(Array)
+      if user_id.kind_of?(Array)
+        user_id.join(',') 
+      else
+        user_id.to_s
+      end
     end
 
   end

--- a/spec/tweetstream/site_stream_client_spec.rb
+++ b/spec/tweetstream/site_stream_client_spec.rb
@@ -135,6 +135,25 @@ describe TweetStream::SiteStreamClient do
       allow(client).to receive(:connection) { conn }
       client.add_user(['1234','5678'])
     end
+
+    describe "accepts a single user_id as" do
+      before :each do
+        conn = double('Connection')
+        expect(conn).to receive(:post).
+          with(:path => "#{config_uri}/add_user.json", :body => { 'user_id' => '1234' }).
+          and_return(FakeHttp.new)
+        allow(client).to receive(:connection) { conn }
+      end
+
+      it "a string" do
+        client.add_user('1234')
+      end
+
+      it "an integer" do
+        client.add_user(1234)
+      end
+    end
+
   end
 
   describe "#remove_user" do
@@ -172,6 +191,24 @@ describe TweetStream::SiteStreamClient do
         and_return(FakeHttp.new)
       allow(client).to receive(:connection) { conn }
       client.remove_user(['1234','5678'])
+    end
+
+    describe "accepts a single user_id as" do
+      before :each do
+        conn = double('Connection')
+        expect(conn).to receive(:post).
+          with(:path => "#{config_uri}/remove_user.json", :body => { 'user_id' => '1234' }).
+          and_return(FakeHttp.new)
+        allow(client).to receive(:connection) { conn }
+      end
+
+      it "a string" do
+        client.remove_user('1234')
+      end
+
+      it "an integer" do
+        client.remove_user(1234)
+      end
     end
   end
 


### PR DESCRIPTION
Fixing [Adding a single user_id to Site Stream connection fails](https://github.com/tweetstream/tweetstream/issues/141).
