### PR TITLE
Change api reference link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [codeclimate]: https://codeclimate.com/github/tweetstream/tweetstream
 [coveralls]: https://coveralls.io/r/tweetstream/tweetstream
 
-TweetStream provides simple Ruby access to [Twitter's Streaming API](https://dev.twitter.com/docs/streaming-api).
+TweetStream provides simple Ruby access to [Twitter's Streaming API](https://dev.twitter.com/docs/streaming-apis).
 
 ## Installation
 


### PR DESCRIPTION
old url is redirect to new url.
