### PR TITLE
Do not throw a warning when epoll is not supported.

### DIFF
--- a/examples/userstream.rb
+++ b/examples/userstream.rb
@@ -18,7 +18,7 @@ client.on_direct_message do |direct_message|
   puts direct_message.text
 end
 
-client.on_timeline_status  do |status|
+client.on_timeline_status do |status|
   puts status.text
 end
 

--- a/lib/tweetstream/client.rb
+++ b/lib/tweetstream/client.rb
@@ -414,8 +414,13 @@ module TweetStream
       if EventMachine.reactor_running?
         connect(path, query_parameters, &block)
       else
-        EventMachine.epoll
-        EventMachine.kqueue
+        if EventMachine.epoll?
+          EventMachine.epoll
+        elsif EventMachine.kqueue?
+          EventMachine.kqueue
+        else
+          Kernel.warn('Your OS does not support epoll or kqueue.')
+        end
 
         EventMachine.run do
           connect(path, query_parameters, &block)


### PR DESCRIPTION
Not every OS supports epoll or kqueue. This PR adds a fallback to kqueue when epoll is not supported.
Epoll is not supported on osx.