### PR TITLE
fix issues for newer rubocop and ruby versions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -53,5 +53,8 @@ Style/RaiseArgs:
 Style/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space
 
-Style/TrailingComma:
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: 'comma'
+
+Style/TrailingCommaInLiteral:
   EnforcedStyleForMultiline: 'comma'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 bundler_args: --without development
 language: ruby
 rvm:
-  - 1.9.3
-  - 2.0.0
   - 2.1
+  - 2.2
+  - 2.3
+  - 2.4.0
   - rbx-2
   - ruby-head
 matrix:

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ end
 group :test do
   gem 'coveralls'
   gem 'rspec', '>= 3'
-  gem 'rubocop', '>= 0.32.1'
+  gem 'rubocop', '~> 0.46.0'
   gem 'simplecov', '>= 0.9'
   gem 'webmock'
 end

--- a/examples/oauth.rb
+++ b/examples/oauth.rb
@@ -15,5 +15,5 @@ client.on_error do |message|
 end
 
 client.track('yankees') do |status|
-  puts "#{status.text}"
+  puts status.text.to_s
 end

--- a/lib/tweetstream.rb
+++ b/lib/tweetstream.rb
@@ -29,7 +29,7 @@ module TweetStream
     end
 
     # Delegate to TweetStream::Client
-    def respond_to?(method, include_private = false)
+    def respond_to_missing?(method, include_private = false)
       new.respond_to?(method, include_private) || super(method, include_private)
     end
   end

--- a/lib/tweetstream/client.rb
+++ b/lib/tweetstream/client.rb
@@ -24,21 +24,23 @@ module TweetStream
   class Client # rubocop:disable ClassLength
     extend Forwardable
 
-    OPTION_CALLBACKS = [:close,
-                        :delete,
-                        :scrub_geo,
-                        :limit,
-                        :error,
-                        :enhance_your_calm,
-                        :unauthorized,
-                        :reconnect,
-                        :inited,
-                        :direct_message,
-                        :timeline_status,
-                        :anything,
-                        :no_data_received,
-                        :status_withheld,
-                        :user_withheld].freeze unless defined?(OPTION_CALLBACKS)
+    unless defined?(OPTION_CALLBACKS)
+      OPTION_CALLBACKS = [:close,
+                          :delete,
+                          :scrub_geo,
+                          :limit,
+                          :error,
+                          :enhance_your_calm,
+                          :unauthorized,
+                          :reconnect,
+                          :inited,
+                          :direct_message,
+                          :timeline_status,
+                          :anything,
+                          :no_data_received,
+                          :status_withheld,
+                          :user_withheld].freeze
+    end
 
     # @private
     attr_accessor(*Configuration::VALID_OPTIONS_KEYS)
@@ -140,7 +142,7 @@ module TweetStream
     # Make a call to the userstream api for currently authenticated user
     def userstream(query_params = {}, &block)
       stream_params = {:host => 'userstream.twitter.com'}
-      query_params.merge!(:extra_stream_parameters => stream_params)
+      query_params[:extra_stream_parameters] = stream_params
       start('/1.1/user.json', query_params, &block)
     end
 
@@ -152,7 +154,7 @@ module TweetStream
         :follow                  => user_ids,
         :extra_stream_parameters => stream_params,
       )
-      query_params.merge!(:with => 'followings') if query_params.delete(:followings)
+      query_params[:with] = 'followings' if query_params.delete(:followings)
       start('/1.1/site.json', query_params, &block)
     end
 
@@ -466,7 +468,7 @@ module TweetStream
       end
 
       @stream.on_max_reconnects do |timeout, retries|
-        fail TweetStream::ReconnectError.new(timeout, retries)
+        raise TweetStream::ReconnectError.new(timeout, retries)
       end
 
       @stream.on_no_data_received { invoke_callback(callbacks['no_data_received']) }

--- a/lib/tweetstream/configuration.rb
+++ b/lib/tweetstream/configuration.rb
@@ -14,13 +14,15 @@ module TweetStream
       :consumer_key,
       :consumer_secret,
       :oauth_token,
-      :oauth_token_secret].freeze
+      :oauth_token_secret,
+    ].freeze
 
     OAUTH_OPTIONS_KEYS = [
       :consumer_key,
       :consumer_secret,
       :oauth_token,
-      :oauth_token_secret].freeze
+      :oauth_token_secret,
+    ].freeze
 
     # By default, don't set a username
     DEFAULT_USERNAME = nil
@@ -38,7 +40,8 @@ module TweetStream
 
     VALID_FORMATS = [
       :basic,
-      :oauth].freeze
+      :oauth,
+    ].freeze
 
     # By default, don't set an application key
     DEFAULT_CONSUMER_KEY = nil

--- a/lib/tweetstream/daemon.rb
+++ b/lib/tweetstream/daemon.rb
@@ -32,7 +32,7 @@ require 'daemons'
 module TweetStream
   class Daemon < TweetStream::Client
     DEFAULT_NAME = 'tweetstream'.freeze
-    DEFAULT_OPTIONS = {:multiple => true}
+    DEFAULT_OPTIONS = {:multiple => true}.freeze
 
     attr_accessor :app_name, :daemon_options
 

--- a/lib/tweetstream/site_stream_client.rb
+++ b/lib/tweetstream/site_stream_client.rb
@@ -101,9 +101,9 @@ module TweetStream
       http = connection.send(method, options.merge(:path => path))
       http.callback do
         if http.response_header.status == 200 && block && block.is_a?(Proc)
-          block.arity == 1 ? block.call(http.response) : block.call
-        else
-          @on_error.call(error_msg) if @on_error && @on_error.is_a?(Proc)
+          block.arity == 1 ? yield(http.response) : yield
+        elsif @on_error && @on_error.is_a?(Proc)
+          @on_error.call(error_msg)
         end
       end
       http.errback do

--- a/lib/tweetstream/version.rb
+++ b/lib/tweetstream/version.rb
@@ -1,3 +1,3 @@
 module TweetStream
-  VERSION = '2.6.1'
+  VERSION = '2.6.1'.freeze
 end

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -54,9 +54,7 @@ def fixture(file)
 end
 
 FakeHttp = Class.new do
-  def callback
-  end
+  def callback; end
 
-  def errback
-  end
+  def errback; end
 end

--- a/spec/tweetstream/client_site_stream_spec.rb
+++ b/spec/tweetstream/client_site_stream_spec.rb
@@ -65,8 +65,7 @@ describe TweetStream::Client do
           @control_response = {'control' =>
             {
               'control_uri' => '/1.1/site/c/01_225167_334389048B872A533002B34D73F8C29FD09EFC50',
-            },
-          }
+            }}
         end
         it 'assigns the control_uri' do
           expect(@stream).to receive(:each).and_yield(@control_response.to_json)

--- a/tweetstream.gemspec
+++ b/tweetstream.gemspec
@@ -17,12 +17,12 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'daemons', '~> 1.1'
   spec.add_dependency 'em-http-request', '>= 1.1.1'
   spec.add_dependency 'em-twitter', '~> 0.3'
-  spec.add_dependency 'twitter', '~> 5.12'
+  spec.add_dependency 'twitter', '~> 6.0'
   spec.add_dependency 'multi_json', '~> 1.3'
   spec.add_development_dependency 'bundler', '~> 1.0'
 
   spec.files = %w(.yardopts CHANGELOG.md CONTRIBUTING.md LICENSE.md README.md tweetstream.gemspec) + Dir['lib/**/*.rb']
 
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 1.9.3'
+  spec.required_ruby_version = '>= 2.1.0'
 end


### PR DESCRIPTION
For now rubocop dependency was set to 'at least `0.32.1` but as rubocop is getting stricter it will just fail if you will bundle and execute rubocop (although nothing changed).

However, I fixed some complains of rubocop and set it to `0.46`.

I tried to update the twitter gem as well to fix #202 but somehow travis can't build rubinious at the moment?

PS: your rubocop rules are pretty weird. Hashrocket style in 2016? 😉 