### PR TITLE
update version so newest code will get downloaded

### DIFF
--- a/lib/tweetstream/version.rb
+++ b/lib/tweetstream/version.rb
@@ -1,3 +1,3 @@
 module TweetStream
-  VERSION = '2.6.1'
+  VERSION = '2.6.2'
 end


### PR DESCRIPTION
I noticed that on_call method was in the code but it didn't come in the bundled version.  By bumping the version I want to make rubygems.org look for the newest stuff.