### PR TITLE
[Fix #212] enable SSL verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ TweetStream.configure do |config|
   config.oauth_token        = 'abcdefghijklmnopqrstuvwxyz'
   config.oauth_token_secret = '0123456789'
   config.auth_method        = :oauth
+
+  # optionally enable SSL verification (recommended for production use)
+  config.verify_peer = true
+  config.private_key_file = '/path/to/key.pem'
+  config.cert_chain_file = '/path/to/cert.pem'
 end
 
 # This will pull a sample of all tweets based on

--- a/lib/tweetstream/client.rb
+++ b/lib/tweetstream/client.rb
@@ -561,6 +561,18 @@ module TweetStream
       end
     end
 
+    def ssl_params
+      return {} unless verify_peer
+
+      {
+        ssl: {
+          verify_peer: verify_peer,
+          cert_chain_file: cert_chain_file,
+          private_key_file: private_key_file
+        }
+      }
+    end
+
     # A utility method used to invoke callback methods against the Client
     def invoke_callback(callback, *args)
       callback.call(*args) if callback
@@ -596,7 +608,7 @@ module TweetStream
         :on_inited  => inited_proc,
         :params     => normalize_filter_parameters(options),
         :proxy      => proxy,
-      }.merge(extra_stream_parameters).merge(auth_params)
+      }.merge(extra_stream_parameters).merge(auth_params).merge(ssl_params)
 
       [stream_params, callbacks]
     end

--- a/lib/tweetstream/configuration.rb
+++ b/lib/tweetstream/configuration.rb
@@ -14,7 +14,11 @@ module TweetStream
       :consumer_key,
       :consumer_secret,
       :oauth_token,
-      :oauth_token_secret].freeze
+      :oauth_token_secret,
+      :private_key_file,
+      :cert_chain_file,
+      :verify_peer
+    ].freeze
 
     OAUTH_OPTIONS_KEYS = [
       :consumer_key,
@@ -52,6 +56,15 @@ module TweetStream
     # By default, don't set a user oauth secret
     DEFAULT_OAUTH_TOKEN_SECRET = nil
 
+    # By default, don't set a private key file
+    DEFAULT_PRIVATE_KEY_FILE = nil
+
+    # By default, don't set a certificate chain file
+    DEFAULT_CERT_CHAIN_FILE = nil
+
+    # By default, don't verify the peer host
+    DEFAULT_VERIFY_PEER = false
+
     # @private
     attr_accessor(*VALID_OPTIONS_KEYS)
 
@@ -86,6 +99,9 @@ module TweetStream
       self.consumer_secret    = DEFAULT_CONSUMER_SECRET
       self.oauth_token        = DEFAULT_OAUTH_TOKEN
       self.oauth_token_secret = DEFAULT_OAUTH_TOKEN_SECRET
+      self.private_key_file   = DEFAULT_PRIVATE_KEY_FILE
+      self.cert_chain_file    = DEFAULT_CERT_CHAIN_FILE
+      self.verify_peer        = DEFAULT_VERIFY_PEER
       self
     end
   end

--- a/spec/tweetstream/client_authentication_spec.rb
+++ b/spec/tweetstream/client_authentication_spec.rb
@@ -20,6 +20,8 @@ describe TweetStream::Client do
     allow(EM::Twitter::Client).to receive(:connect).and_return(@stream)
   end
 
+  after { TweetStream.reset }
+
   describe 'basic auth' do
     before do
       TweetStream.configure do |config|
@@ -77,6 +79,30 @@ describe TweetStream::Client do
         },
         :proxy => nil,
       ).and_return(@stream)
+
+      @client.track('monday')
+    end
+  end
+
+  describe 'ssl' do
+    before do
+      TweetStream.configure do |config|
+        config.verify_peer = true
+        config.private_key_file = '/path/to/key.pem'
+        config.cert_chain_file = '/path/to/cert.pem'
+      end
+
+      @client = TweetStream::Client.new
+    end
+
+    it 'uses SSL' do
+      expect(EM::Twitter::Client).to receive(:connect).with(hash_including(
+        ssl: {
+          verify_peer: true,
+          private_key_file: '/path/to/key.pem',
+          cert_chain_file: '/path/to/cert.pem'
+        }
+      ))
 
       @client.track('monday')
     end


### PR DESCRIPTION
This PR leverages the [SSL configuration options](https://github.com/tweetstream/em-twitter#ssl) in `em-twitter` to allow the user to verify the host when connecting to the Twitter streaming API. This is intended to resolve the vulnerability detailed in https://securitylab.github.com/advisories/GHSL-2020-096-tweetstream-tweetstream/

Resolves https://github.com/tweetstream/tweetstream/issues/212.